### PR TITLE
Add Build Log to SonarException output

### DIFF
--- a/sonar/builders/docker.py
+++ b/sonar/builders/docker.py
@@ -50,10 +50,20 @@ def docker_build(
         )
         return image
     except (docker.errors.BuildError) as e:
-        raise SonarBuildError from e
+        raise SonarBuildError(_get_build_log(e)) from e
 
     except (docker.errors.APIError) as e:
-        raise SonarAPIError from e
+        raise SonarBuildError from e
+
+
+def _get_build_log(e: docker.errors.BuildError) -> str:
+    build_logs = "\n"
+    for item in e.build_log:
+        if "stream" not in item:
+            continue
+        item_str = item["stream"]
+        build_logs += item_str
+    return build_logs
 
 
 def docker_pull(

--- a/sonar/builders/docker.py
+++ b/sonar/builders/docker.py
@@ -53,7 +53,7 @@ def docker_build(
         raise SonarBuildError(_get_build_log(e)) from e
 
     except (docker.errors.APIError) as e:
-        raise SonarBuildError from e
+        raise SonarAPIError from e
 
 
 def _get_build_log(e: docker.errors.BuildError) -> str:


### PR DESCRIPTION
This PR adds the docker build log to the raised exception. Sample output after change

```bash
image_build_start: operator
[operator-context-dockerfile/docker_build] stage-started operator-context-dockerfile: 1/8
Traceback (most recent call last):
  File "/Users/cianhatton/venv/default/lib/python3.9/site-packages/sonar/builders/docker.py", line 49, in docker_build
    image, _ = client.images.build(
  File "/Users/cianhatton/venv/default/lib/python3.9/site-packages/docker/models/images.py", line 287, in build
    raise BuildError(chunk['error'], result_stream)
docker.errors.BuildError: The command '/bin/sh -c mkdir /build && go build -i -o /build/mongodb-enterprise-operator         -ldflags="-s -w -X github.com/10gen/ops-manager-kubernetes/pkg/util.OperatorVersion=${release_version}         -X github.com/10gen/ops-manager-kubernetes/pkg/util.LogAutomationConfigDiff=${log_automation_config_diff}"' returned a non-zero code: 1

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/cianhatton/checkouts/ops-manager-kubernetes/pipeline.py", line 736, in <module>
    main()
  File "/Users/cianhatton/checkouts/ops-manager-kubernetes/pipeline.py", line 730, in main
    build_all_images(
  File "/Users/cianhatton/checkouts/ops-manager-kubernetes/pipeline.py", line 671, in build_all_images
    build_image(image, build_configuration)
  File "/Users/cianhatton/checkouts/ops-manager-kubernetes/pipeline.py", line 656, in build_image
    get_builder_function_for_image_name()[image_name](build_configuration)
  File "/Users/cianhatton/checkouts/ops-manager-kubernetes/pipeline.py", line 264, in build_operator_image
    sonar_build_image(image_name, build_configuration, args)
  File "/Users/cianhatton/checkouts/ops-manager-kubernetes/pipeline.py", line 222, in sonar_build_image
    process_image(
  File "/Users/cianhatton/venv/default/lib/python3.9/site-packages/sonar/sonar.py", line 733, in process_image
    task_docker_build(ctx)
  File "/Users/cianhatton/venv/default/lib/python3.9/site-packages/sonar/sonar.py", line 573, in task_docker_build
    image = docker_build(docker_context, dockerfile, buildargs=buildargs, labels=labels)
  File "/Users/cianhatton/venv/default/lib/python3.9/site-packages/sonar/builders/docker.py", line 54, in docker_build
    raise SonarBuildError(_get_build_log(e)) from e
sonar.builders.SonarBuildError:
Step 1/16 : FROM golang:1.15 as builder
 ---> c62391fc0216
Step 2/16 : ARG release_version
 ---> Using cache
 ---> ee43e28d3e25
Step 3/16 : ARG log_automation_config_diff
 ---> Using cache
 ---> 0515b1178bcb
Step 4/16 : COPY go.sum go.mod /go/src/github.com/10gen/ops-manager-kubernetes/
 ---> Using cache
 ---> 8274c2db5b8e
Step 5/16 : WORKDIR /go/src/github.com/10gen/ops-manager-kubernetes
 ---> Using cache
 ---> 02e1cac58cc7
Step 6/16 : RUN go mod download
 ---> Using cache
 ---> 1482e9be8da3
Step 7/16 : COPY . /go/src/github.com/10gen/ops-manager-kubernetes
 ---> Using cache
 ---> 371a5fcb7caf
Step 8/16 : RUN mkdir /build && go build -i -o /build/mongodb-enterprise-operator         -ldflags="-s -w -X github.com/10gen/ops-manager-kubernetes/pkg/util.OperatorVersion=${release_version}         -X github.com/10gen/ops-manager-kubernetes/pkg/util.LogAutomationConfigDiff=${log_automation_config_diff}"
 ---> Running in 0d5f26f2424c
go: inconsistent vendoring in /go/src/github.com/10gen/ops-manager-kubernetes:
	github.com/aws/aws-sdk-go@v1.38.45: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/blang/semver@v3.5.1+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/emicklei/go-restful@v2.9.6+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/evanphx/json-patch@v4.11.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/ghodss/yaml@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/go-logr/logr@v0.4.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/go-openapi/spec@v0.19.8: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/go-openapi/swag@v0.19.9: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/google/uuid@v1.1.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/hashicorp/go-multierror@v1.1.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/imdario/mergo@v0.3.12: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/mailru/easyjson@v0.7.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/mongodb/mongodb-kubernetes-operator@v0.6.3-0.20210701150938-10b4411ceb6d: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/pkg/errors@v0.9.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/prometheus/client_golang@v1.11.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/prometheus/common@v0.26.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/spf13/cast@v1.3.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/spf13/pflag@v1.0.5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/stretchr/objx@v0.3.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/stretchr/testify@v1.7.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/xdg/stringprep@v1.0.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	go.uber.org/zap@v1.17.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/lint@v0.0.0-20210508222113-6edffad5e616: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/oauth2@v0.0.0-20210402161424-2e8d93401602: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/sys@v0.0.0-20210630005230-0f9fa26af87c: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/tools@v0.1.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/api@v0.21.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/apimachinery@v0.21.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/client-go@v0.21.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/code-generator@v0.21.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	sigs.k8s.io/controller-runtime@v0.9.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory

```