### PR TITLE
Add platform switch to configure image arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 htmlcov
 
 sonar.egg-info/*
+sonar.iml

--- a/sonar/builders/docker.py
+++ b/sonar/builders/docker.py
@@ -17,6 +17,7 @@ def docker_build(
     dockerfile: str,
     buildargs: Optional[Dict[str, str]] = None,
     labels: Optional[Dict[str, str]] = None,
+    platform: Optional[str] = None,
 ):
     """Builds a docker image."""
     client = docker_client()
@@ -33,16 +34,13 @@ def docker_build(
 
     buildargs_str = buildarg_from_dict(buildargs)
     labels_str = labels_from_dict(labels)
+    platform_str = f" --platform {platform}" if platform is not None else ""
 
-    logger.info(
-        "docker build {context} -f {dockerfile} {buildargs} {labels}".format(
-            context=path, dockerfile=dockerfile, buildargs=buildargs_str, labels=labels_str,
-        )
-    )
+    logger.info(f"docker build {path}{platform_str} -f {dockerfile} {buildargs_str} {labels_str}")
 
     try:
         image, _ = client.images.build(
-            path=path, dockerfile=dockerfile, tag=image_name, buildargs=buildargs, labels=labels,
+            path=path, dockerfile=dockerfile, tag=image_name, buildargs=buildargs, labels=labels, platform=platform,
         )
         return image
     except (docker.errors.BuildError) as e:

--- a/sonar/sonar.py
+++ b/sonar/sonar.py
@@ -570,7 +570,7 @@ def task_docker_build(ctx: Context):
 
     labels = interpolate_dict(ctx, ctx.stage.get("labels", {}))
 
-    image = docker_build(docker_context, dockerfile, buildargs=buildargs, labels=labels)
+    image = docker_build(docker_context, dockerfile, buildargs=buildargs, labels=labels, platform=ctx.image.get("platform"))
 
     for output in ctx.stage["output"]:
         registry = ctx.I(output["registry"])

--- a/test/yaml_scenario11.yaml
+++ b/test/yaml_scenario11.yaml
@@ -1,0 +1,43 @@
+vars:
+  registry: somereg
+
+images:
+  - name: image1
+    vars:
+      context: .
+
+    inputs:
+      - input0
+
+    platform: linux/amd64
+
+    stages:
+    - name: stage0
+      task_type: docker_build
+
+      labels:
+        label-0: value-0
+
+      dockerfile: Dockerfile
+      output:
+      - registry: $(inputs.params.registry)/something
+        tag: something
+
+  - name: image2
+    vars:
+      context: .
+
+    inputs:
+      - input0
+
+    stages:
+      - name: stage0
+        task_type: docker_build
+
+        labels:
+          label-1: value-1
+
+        dockerfile: Dockerfile
+        output:
+          - registry: $(inputs.params.registry)/something
+            tag: something


### PR DESCRIPTION
Adds platform setting on image level in inventory to allow multi-platform docker builds.
Platform is then passed to docker build which is analogous to invoking
`docker build --platform <platform>`