### PR TITLE
Docker build using cli

### DIFF
--- a/sonar/builders/docker.py
+++ b/sonar/builders/docker.py
@@ -61,6 +61,24 @@ def docker_build_cli(
         labels=Optional[Dict[str, str]],
         platform=Optional[str]
 ):
+    args = get_docker_build_cli_args(path=path, dockerfile=dockerfile, tag=tag, buildargs=buildargs, labels=labels, platform=platform)
+
+    args_str = " ".join(args)
+    logger.info(f"executing cli docker build: {args_str}")
+
+    cp = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if cp.returncode != 0:
+        raise SonarAPIError(cp.stderr)
+
+
+def get_docker_build_cli_args(
+        path: str,
+        dockerfile: str,
+        tag: str,
+        buildargs: Optional[Dict[str, str]],
+        labels=Optional[Dict[str, str]],
+        platform=Optional[str]
+):
     args = ["docker", "build", path, "-f", dockerfile, "-t", tag]
     if buildargs is not None:
         for k, v in buildargs.items():
@@ -76,12 +94,7 @@ def docker_build_cli(
         args.append("--platform")
         args.append(platform)
 
-    args_str = " ".join(args)
-    logger.info(f"executing cli docker build: {args_str}")
-
-    cp = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if cp.returncode != 0:
-        raise SonarAPIError(cp.stderr)
+    return args
 
 
 def docker_pull(

--- a/sonar/builders/docker.py
+++ b/sonar/builders/docker.py
@@ -61,7 +61,12 @@ def docker_build_cli(
         labels=Optional[Dict[str, str]],
         platform=Optional[str]
 ):
-    args = get_docker_build_cli_args(path=path, dockerfile=dockerfile, tag=tag, buildargs=buildargs, labels=labels, platform=platform)
+    dockerfile_path = dockerfile
+    # if dockerfile is relative it has to be set as relative to context (path)
+    if not dockerfile_path.startswith('/'):
+        dockerfile_path = f"{path}/{dockerfile_path}"
+
+    args = get_docker_build_cli_args(path=path, dockerfile=dockerfile_path, tag=tag, buildargs=buildargs, labels=labels, platform=platform)
 
     args_str = " ".join(args)
     logger.info(f"executing cli docker build: {args_str}")
@@ -79,7 +84,7 @@ def get_docker_build_cli_args(
         labels=Optional[Dict[str, str]],
         platform=Optional[str]
 ):
-    args = ["docker", "build", path, "-f", dockerfile, "-t", tag]
+    args = ["docker", "buildx", "build", "--progress", "plain", path, "-f", dockerfile, "-t", tag]
     if buildargs is not None:
         for k, v in buildargs.items():
             args.append("--build-arg")

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -111,6 +111,6 @@ def test_platform_is_passed_to_docker_build(_docker_build, _docker_tag):
 
 
 def test_get_docker_build_cli_args():
-    assert "docker build . -f dockerfile -t image:latest" == " ".join(get_docker_build_cli_args(".", "dockerfile", "image:latest", None, None, None))
-    assert "docker build . -f dockerfile -t image:latest --build-arg a=1 --build-arg long_arg=long_value --label l1=v1 --label l2=v2 --platform linux/amd64" == " ".join(
+    assert "docker buildx build --progress plain . -f dockerfile -t image:latest" == " ".join(get_docker_build_cli_args(".", "dockerfile", "image:latest", None, None, None))
+    assert "docker buildx build --progress plain . -f dockerfile -t image:latest --build-arg a=1 --build-arg long_arg=long_value --label l1=v1 --label l2=v2 --platform linux/amd64" == " ".join(
         get_docker_build_cli_args(".", "dockerfile", "image:latest", {"a": "1", "long_arg": "long_value"}, {"l1": "v1", "l2": "v2"}, "linux/amd64"))

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,11 +1,11 @@
+from types import SimpleNamespace as sn
+from unittest.mock import patch, mock_open, call
+
+from sonar.builders.docker import get_docker_build_cli_args
 from sonar.sonar import (
     process_image,
     find_dockerfile,
 )
-
-from types import SimpleNamespace as sn
-
-from unittest.mock import patch, mock_open, call
 
 
 @patch("sonar.sonar.docker_push")
@@ -14,11 +14,11 @@ from unittest.mock import patch, mock_open, call
 @patch("sonar.sonar.urlretrieve")
 @patch("sonar.sonar.create_ecr_repository")
 def test_dockerfile_from_url(
-    patched_docker_build,
-    patched_docker_tag,
-    patched_docker_push,
-    patched_urlretrive,
-    patched_create_ecr_repository,
+        patched_docker_build,
+        patched_docker_tag,
+        patched_docker_push,
+        patched_urlretrive,
+        patched_create_ecr_repository,
 ):
     with open("test/yaml_scenario6.yaml") as fd:
         with patch("builtins.open", mock_open(read_data=fd.read())) as _mock_file:
@@ -108,3 +108,9 @@ def test_platform_is_passed_to_docker_build(_docker_build, _docker_tag):
 
     _docker_build.assert_has_calls(calls)
     _docker_build.assert_called()
+
+
+def test_get_docker_build_cli_args():
+    assert "docker build . -f dockerfile -t image:latest" == " ".join(get_docker_build_cli_args(".", "dockerfile", "image:latest", None, None, None))
+    assert "docker build . -f dockerfile -t image:latest --build-arg a=1 --build-arg long_arg=long_value --label l1=v1 --label l2=v2 --platform linux/amd64" == " ".join(
+        get_docker_build_cli_args(".", "dockerfile", "image:latest", {"a": "1", "long_arg": "long_value"}, {"l1": "v1", "l2": "v2"}, "linux/amd64"))


### PR DESCRIPTION
Docker build is executed now as a docker build command in subprocess.
Docker-py library has bugs related to handling platform switch which results in errors or incorrect images' platform when
building on M1.