### PR TITLE
add --load flag

### DIFF
--- a/sonar/builders/docker.py
+++ b/sonar/builders/docker.py
@@ -84,7 +84,7 @@ def get_docker_build_cli_args(
         labels=Optional[Dict[str, str]],
         platform=Optional[str]
 ):
-    args = ["docker", "buildx", "build", "--progress", "plain", path, "-f", dockerfile, "-t", tag]
+    args = ["docker", "buildx", "build", "--load" , "--progress", "plain", path, "-f", dockerfile, "-t", tag]
     if buildargs is not None:
         for k, v in buildargs.items():
             args.append("--build-arg")


### PR DESCRIPTION
[](https://docs.docker.com/engine/reference/commandline/buildx_build/#load)

When trying to enable multi-arch builds, I needed this flag to find the build in `docker images` and then create the manifest.

_Shorthand for [--output=type=docker](https://docs.docker.com/engine/reference/commandline/buildx_build/#docker). Will automatically load the single-platform build result to docker images._

